### PR TITLE
Some helm-chart fixes

### DIFF
--- a/helm-chart/templates/configmap.yaml
+++ b/helm-chart/templates/configmap.yaml
@@ -13,17 +13,17 @@ data:
 {{- else }}
   HEDERA_NETWORK: {{ required "A valid HEDERA_NETWORK must be present in either .Values.config.local.HEDERA_NETWORK or .Values.config.hosted.HEDERA_NETWORK " (or .Values.config.local.HEDERA_NETWORK .Values.config.hosted.HEDERA_NETWORK) }}
 {{- end }}
-  CHAIN_ID: {{ .valu}}
-  MIRROR_NODE_URL: {{ .Values.config.MIRROR_NODE_URL  }}
-  LOCAL_NODE: {{ .Values.config.LOCAL_NODE }}
-  SERVER_PORT: {{ .Values.config.SERVER_PORT }}
-  CHAIN_ID: {{ .Values.config.CHAIN_ID }}
-  DEFAULT_RATE_LIMIT: {{ .Values.config.DEFAULT_RATE_LIMIT }}
-  TIER_1_RATE_LIMIT: {{ .Values.config.TIER_1_RATE_LIMIT }}
-  TIER_2_RATE_LIMIT: {{ .Values.config.TIER_2_RATE_LIMIT }}
-  TIER_3_RATE_LIMIT: {{ .Values.config.TIER_3_RATE_LIMIT }}
-  LIMIT_DURATION: {{ .Values.config.LIMIT_DURATION }}
-  HBAR_RATE_LIMIT_TINYBAR: {{ .Values.config.HBAR_RATE_LIMIT_TINYBAR }}
-  HBAR_RATE_LIMIT_DURATION: {{ .Values.config.HBAR_RATE_LIMIT_DURATION }}
-  ETH_GET_LOGS_BLOCK_RANGE_LIMIT: {{ .Values.config.ETH_GET_LOGS_BLOCK_RANGE_LIMIT }}
-  RATE_LIMIT_DISABLED: {{ .Values.config.RATE_LIMIT_DISABLED }}
+  MIRROR_NODE_URL: {{ quote  .Values.config.MIRROR_NODE_URL  }}
+  LOCAL_NODE: {{ quote .Values.config.LOCAL_NODE  }}
+  SERVER_PORT: {{ quote .Values.config.SERVER_PORT }}
+  CHAIN_ID: {{ quote .Values.config.CHAIN_ID }}
+  DEFAULT_RATE_LIMIT: {{ quote .Values.config.DEFAULT_RATE_LIMIT }}
+  TIER_1_RATE_LIMIT: {{ quote .Values.config.TIER_1_RATE_LIMIT }}
+  TIER_2_RATE_LIMIT: {{ quote .Values.config.TIER_2_RATE_LIMIT }}
+  TIER_3_RATE_LIMIT: {{ quote .Values.config.TIER_3_RATE_LIMIT }}
+  LIMIT_DURATION: {{ quote .Values.config.LIMIT_DURATION }}
+  HBAR_RATE_LIMIT_TINYBAR: {{ quote .Values.config.HBAR_RATE_LIMIT_TINYBAR }}
+  HBAR_RATE_LIMIT_DURATION: {{ quote .Values.config.HBAR_RATE_LIMIT_DURATION }}
+  ETH_GET_LOGS_BLOCK_RANGE_LIMIT: {{ quote .Values.config.ETH_GET_LOGS_BLOCK_RANGE_LIMIT }}
+  RATE_LIMIT_DISABLED: {{ quote .Values.config.RATE_LIMIT_DISABLED }}
+  DEV_MODE: {{ quote .Values.config.DEV_MODE }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -35,8 +35,6 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: CHAIN_ID
-            value: {{ .Values.config.CHAIN_ID | squote }}
-          - name: CHAIN_ID
             valueFrom:
               configMapKeyRef:
                 name: {{ include "json-rpc-relay.fullname" . }}
@@ -147,14 +145,14 @@ spec:
         ports:
           - containerPort: {{ .Values.ports.containerPort }}
             name: {{ .Values.ports.name  }}
-        livenessProbe:
-          httpGet:
-            path: /health/liveness
-            port: jsonrpcrelay
-        readinessProbe:
-          httpGet:
-            path: /health/readiness
-            port: jsonrpcrelay
+        #livenessProbe:
+        #  httpGet:
+        #    path: /health/liveness
+        #    port: jsonrpcrelay
+        #readinessProbe:
+        #  httpGet:
+        #    path: /health/readiness
+        #    port: jsonrpcrelay
         resources:
           {{- toYaml .Values.resources | indent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
quotes in configmap because it does not interpret well integers from values.yaml (even when they are in quotes)

remove liveness and readiness probes in deployment since they don't work. 
remove chainID since it is redundant and it just confuses kubernetes